### PR TITLE
Fix README conflict markers and invalid import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-<<<<<<< HEAD
 # snake-on-page
-snake game that exists on top of page contents
-=======
-# React + Vite
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A snake game that runs on top of the web page using React and Vite.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
->>>>>>> 3e0a243 (first commit)
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@
 import SnakeGame from './lib/SnakeGame'
 import GameInterface from './lib/GameInterface'
 // import './App.css'
-import Test from '../'
 
 function App() {
 
@@ -10,7 +9,6 @@ function App() {
     <>
       {/* <Snake /> */}
       <GameInterface />
-      {/* <Test /> */}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- clean up leftover merge markers in README
- remove stray test import

## Testing
- `npm run build`
- `npm run dev` *(fails: process stops due to background job, but log shows server started)*

------
https://chatgpt.com/codex/tasks/task_e_684ac54fe218832bb1e433ce2cdb9c0c