### PR TITLE
chore: add gh-pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy to GitHub Pages
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add GitHub Action to deploy to gh-pages when a PR merging into main is closed

## Testing
- `npm run lint` *(fails: React project has numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c119fdb98832ba475fbcd0729cc33