### PR TITLE
Improve scoreboard styling

### DIFF
--- a/src/lib/GameInterface.css
+++ b/src/lib/GameInterface.css
@@ -7,3 +7,16 @@
   user-select: none;
   overflow: hidden;
 }
+
+.score-board {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 999;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 1.25rem;
+  padding: 4px 12px;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+}

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -25,9 +25,13 @@ const GameInterface = () => {
 
   return (
     <div className='game-interface'>
-      <span style={{ position: 'fixed', zIndex: 999, top: 0, backgroundColor: "white" }}>{score}</span>
+      <div className='score-board'>Score: {score}</div>
       {/* <img src={`${(baseURL)}mountain.jpg`} alt="My Image" /> */}
-      <SnakeGame mapImporterName={maps[mapIndex]} nextMap={() => setMapIndex(mapIndex + 1)} addScore={() => setScore(prev => prev + 1)} />
+      <SnakeGame
+        mapImporterName={maps[mapIndex]}
+        nextMap={() => setMapIndex(mapIndex + 1)}
+        addScore={() => setScore(prev => prev + 1)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- beautify score display

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684bb55aed64832b8cd9305fc62ff7ce