### PR TITLE
Fix loading screen

### DIFF
--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -28,32 +28,31 @@ const GameInterface = () => {
       'tritanopia',
     ]
 
-    const items = []
-    mapList.forEach(name => {
-      types.forEach(type => {
-        items.push({ name, type })
-      })
-    })
+    const items = mapList.flatMap(name =>
+      types.map(type => ({ name, type })))
 
     const totalImages = items.length
     setStatus({ loaded: 0, total: totalImages, item: '' })
+    let loadedCount = 0
 
-    const loadNext = (index) => {
-      if (index >= items.length) {
-        setLoading(false)
-        return
-      }
-      const { name, type } = items[index]
+    const loadImage = ({ name, type }) => {
       const suffix = type === 'normal' ? '' : `_${type}`
       const img = new Image()
       img.src = `${baseURL}maps/${name}/map${suffix}.png`
-      setStatus({ loaded: index, total: totalImages, item: `${name}${suffix}` })
-      img.onload = img.onerror = () => {
-        loadNext(index + 1)
-      }
+      return new Promise(resolve => {
+        img.onload = img.onerror = () => {
+          loadedCount += 1
+          setStatus({
+            loaded: loadedCount,
+            total: totalImages,
+            item: `${name}${suffix}`,
+          })
+          resolve()
+        }
+      })
     }
 
-    loadNext(0)
+    Promise.all(items.map(loadImage)).then(() => setLoading(false))
   }, [baseURL, maps])
 
 


### PR DESCRIPTION
## Summary
- optimize preload logic by fetching images concurrently

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e5d4c8dec832ba858950b1e31e2aa