### PR TITLE
improve scoreboard animation and style

### DIFF
--- a/src/lib/GameInterface.css
+++ b/src/lib/GameInterface.css
@@ -13,15 +13,28 @@
   top: 10px;
   left: 10px;
   z-index: 999;
-  background-color: rgba(0, 0, 0, 0.6);
-  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: linear-gradient(#222, #000);
+  color: #7fff00;
   font-size: 1.25rem;
-  padding: 4px 12px;
+  padding: 6px 12px;
   border-radius: 8px;
-  font-family: Arial, sans-serif;
+  border: 2px solid #7fff00;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  font-family: 'Courier New', monospace;
 }
 
-.score-board.animate {
+.score-label {
+  color: #fff;
+}
+
+.score-value {
+  font-weight: bold;
+}
+
+.score-value.animate {
   animation: score-bump 0.3s ease;
 }
 

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -73,7 +73,10 @@ const GameInterface = () => {
         <LoadingScreen item={status.item} loaded={status.loaded} total={status.total} />
       )}
       <div className='game-interface'>
-        <div className={`score-board${animateScore ? ' animate' : ''}`}>Score: {score}</div>
+        <div className="score-board">
+          <span className="score-label">Score:</span>
+          <span className={`score-value${animateScore ? ' animate' : ''}`}>{score}</span>
+        </div>
         {/* <img src={`${(baseURL)}mountain.jpg`} alt="My Image" /> */}
         <SnakeGame
           mapImporterName={maps[mapIndex]}


### PR DESCRIPTION
## Summary
- animate only the score text
- style scoreboard with a game-like look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e9744b250832baa4ce71a4070ec40