### PR TITLE
Add map name display

### DIFF
--- a/src/lib/GameInterface.css
+++ b/src/lib/GameInterface.css
@@ -26,6 +26,21 @@
   font-family: 'Courier New', monospace;
 }
 
+.map-name-box {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 999;
+  background: linear-gradient(#222, #000);
+  color: #7fff00;
+  font-size: 1.25rem;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 2px solid #7fff00;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  font-family: 'Courier New', monospace;
+}
+
 .score-label {
   color: #fff;
 }

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -77,6 +77,7 @@ const GameInterface = () => {
           <span className="score-label">Score:</span>
           <span className={`score-value${animateScore ? ' animate' : ''}`}>{score}</span>
         </div>
+        <div className="map-name-box">{maps[mapIndex]}</div>
         {/* <img src={`${(baseURL)}mountain.jpg`} alt="My Image" /> */}
         <SnakeGame
           mapImporterName={maps[mapIndex]}


### PR DESCRIPTION
## Summary
- show the current map name in GameInterface
- style map name box like the score board

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ea1f5ae44832b8f3244b81608a179