### PR TITLE
Add end screen with map scores

### DIFF
--- a/src/EndScreen.jsx
+++ b/src/EndScreen.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types'
+import styles from './EndScreen.module.css'
+
+const formatMapName = name => name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+
+const EndScreen = ({ scores, maps }) => (
+  <div className={styles.endScreen}>
+    <div className={styles.title}>Game Over</div>
+    <ul className={styles.scoreList}>
+      {maps.map(name => (
+        <li key={name} className={styles.scoreItem}>
+          <span className={styles.mapName}>{formatMapName(name)}:</span>
+          <span>{scores[name] || 0}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+EndScreen.propTypes = {
+  scores: PropTypes.object.isRequired,
+  maps: PropTypes.arrayOf(PropTypes.string).isRequired,
+}
+
+export default EndScreen

--- a/src/EndScreen.module.css
+++ b/src/EndScreen.module.css
@@ -1,0 +1,36 @@
+.endScreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.8);
+  color: #7fff00;
+  font-family: 'Courier New', monospace;
+  z-index: 999;
+}
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 16px;
+}
+
+.scoreList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+}
+
+.scoreItem {
+  margin: 4px 0;
+  display: flex;
+  gap: 8px;
+}
+
+.mapName {
+  color: #fff;
+}

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -1,5 +1,6 @@
 import SnakeGame from './SnakeGame'
 import LoadingScreen from '../LoadingScreen'
+import EndScreen from '../EndScreen'
 import { useState, useEffect, useMemo } from 'react'
 import "./GameInterface.css"
 
@@ -8,7 +9,9 @@ import "./GameInterface.css"
 const GameInterface = () => {
   const [mapIndex, setMapIndex] = useState(0)
   const [score, setScore] = useState(0)
+  const [mapScores, setMapScores] = useState({})
   const [animateScore, setAnimateScore] = useState(false)
+  const [showEnd, setShowEnd] = useState(false)
   const [loading, setLoading] = useState(true)
   const [status, setStatus] = useState({ loaded: 0, total: 0, item: '' })
   const maps = useMemo(() => ({
@@ -28,7 +31,19 @@ const GameInterface = () => {
 
   const addScore = () => {
     setScore(prev => prev + 1)
+    setMapScores(prev => ({
+      ...prev,
+      [maps[mapIndex]]: (prev[maps[mapIndex]] || 0) + 1,
+    }))
     setAnimateScore(true)
+  }
+
+  const handleNextMap = () => {
+    if (mapIndex + 1 >= Object.keys(maps).length) {
+      setShowEnd(true)
+    } else {
+      setMapIndex(mapIndex + 1)
+    }
   }
 
   useEffect(() => {
@@ -79,19 +94,23 @@ const GameInterface = () => {
       {loading && (
         <LoadingScreen item={status.item} loaded={status.loaded} total={status.total} />
       )}
-      <div className='game-interface'>
-        <div className="score-board">
-          <span className="score-label">Score:</span>
-          <span className={`score-value${animateScore ? ' animate' : ''}`}>{score}</span>
+      {showEnd ? (
+        <EndScreen scores={mapScores} maps={Object.values(maps)} />
+      ) : (
+        <div className='game-interface'>
+          <div className="score-board">
+            <span className="score-label">Score:</span>
+            <span className={`score-value${animateScore ? ' animate' : ''}`}>{score}</span>
+          </div>
+          <div className="map-name-box">{formatMapName(maps[mapIndex])}</div>
+          {/* <img src={`${(baseURL)}mountain.jpg`} alt="My Image" /> */}
+          <SnakeGame
+            mapImporterName={maps[mapIndex]}
+            nextMap={handleNextMap}
+            addScore={addScore}
+          />
         </div>
-        <div className="map-name-box">{formatMapName(maps[mapIndex])}</div>
-        {/* <img src={`${(baseURL)}mountain.jpg`} alt="My Image" /> */}
-        <SnakeGame
-          mapImporterName={maps[mapIndex]}
-          nextMap={() => setMapIndex(mapIndex + 1)}
-          addScore={addScore}
-        />
-      </div>
+      )}
     </>
   );
 }

--- a/src/simulate.js
+++ b/src/simulate.js
@@ -1,4 +1,5 @@
 import { createCanvas, loadImage } from 'canvas';
+/* eslint-env node */
 import { simulate } from '@bjornlu/colorblind'
 import fs from 'fs';
 


### PR DESCRIPTION
## Summary
- add `EndScreen` component to display final scores by map
- track scores for each map
- show `EndScreen` after the last map finishes
- style the end screen as a full screen overlay
- silence eslint error in `simulate.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684fc22d5cec832ba6c81809bbb6a6be