### PR TITLE
Add restart button to end screen

### DIFF
--- a/src/EndScreen.jsx
+++ b/src/EndScreen.jsx
@@ -3,7 +3,7 @@ import styles from './EndScreen.module.css'
 
 const formatMapName = name => name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
 
-const EndScreen = ({ scores, maps }) => (
+const EndScreen = ({ scores, maps, onRestart }) => (
   <div className={styles.endScreen}>
     <div className={styles.title}>Game Over</div>
     <ul className={styles.scoreList}>
@@ -14,12 +14,16 @@ const EndScreen = ({ scores, maps }) => (
         </li>
       ))}
     </ul>
+    <button className={styles.restartButton} onClick={onRestart}>
+      Start Over
+    </button>
   </div>
 )
 
 EndScreen.propTypes = {
   scores: PropTypes.object.isRequired,
   maps: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onRestart: PropTypes.func.isRequired,
 }
 
 export default EndScreen

--- a/src/EndScreen.module.css
+++ b/src/EndScreen.module.css
@@ -34,3 +34,18 @@
 .mapName {
   color: #fff;
 }
+
+.restartButton {
+  background: linear-gradient(#222, #000);
+  color: #7fff00;
+  font-family: 'Courier New', monospace;
+  font-size: 1rem;
+  padding: 8px 16px;
+  border: 2px solid #7fff00;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.restartButton:hover {
+  background: linear-gradient(#333, #111);
+}

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -46,6 +46,14 @@ const GameInterface = () => {
     }
   }
 
+  const handleRestart = () => {
+    setMapIndex(0)
+    setScore(0)
+    setMapScores({})
+    setShowEnd(false)
+    window.scrollTo(0, 0)
+  }
+
   useEffect(() => {
     const mapList = Object.values(maps)
     const types = [
@@ -95,7 +103,11 @@ const GameInterface = () => {
         <LoadingScreen item={status.item} loaded={status.loaded} total={status.total} />
       )}
       {showEnd ? (
-        <EndScreen scores={mapScores} maps={Object.values(maps)} />
+        <EndScreen
+          scores={mapScores}
+          maps={Object.values(maps)}
+          onRestart={handleRestart}
+        />
       ) : (
         <div className='game-interface'>
           <div className="score-board">


### PR DESCRIPTION
## Summary
- allow players to start a new run from the end screen
- style new button to match retro overlay

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fd41721e8832b870d492cb7a55117