### PR TITLE
Add colour blindness explanation

### DIFF
--- a/src/EndScreen.jsx
+++ b/src/EndScreen.jsx
@@ -3,7 +3,19 @@ import styles from './EndScreen.module.css'
 
 const formatMapName = name => name.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
 
-const EndScreen = ({ scores, maps, onRestart }) => (
+const descriptions = {
+  normal: 'You experienced normal colour vision.',
+  protanopia:
+    'Protanopia reduces sensitivity to red light, making red and green hard to tell apart.',
+  deuteranopia:
+    'Deuteranopia diminishes green light perception, also affecting red–green distinction.',
+  tritanopia:
+    'Tritanopia lowers sensitivity to blue light and shifts blue–yellow hues.',
+  achromatopsia:
+    'Achromatopsia removes all colour, showing only shades of grey.',
+}
+
+const EndScreen = ({ scores, maps, onRestart, deficiency }) => (
   <div className={styles.endScreen}>
     <div className={styles.title}>Game Over</div>
     <ul className={styles.scoreList}>
@@ -14,6 +26,9 @@ const EndScreen = ({ scores, maps, onRestart }) => (
         </li>
       ))}
     </ul>
+    {descriptions[deficiency] && (
+      <p className={styles.description}>{descriptions[deficiency]}</p>
+    )}
     <button className={styles.restartButton} onClick={onRestart}>
       Start Over
     </button>
@@ -24,6 +39,7 @@ EndScreen.propTypes = {
   scores: PropTypes.object.isRequired,
   maps: PropTypes.arrayOf(PropTypes.string).isRequired,
   onRestart: PropTypes.func.isRequired,
+  deficiency: PropTypes.string,
 }
 
 export default EndScreen

--- a/src/EndScreen.module.css
+++ b/src/EndScreen.module.css
@@ -49,3 +49,10 @@
 .restartButton:hover {
   background: linear-gradient(#333, #111);
 }
+
+.description {
+  margin-top: 16px;
+  color: #fff;
+  text-align: center;
+  max-width: 80%;
+}

--- a/src/lib/GameInterface.jsx
+++ b/src/lib/GameInterface.jsx
@@ -14,6 +14,7 @@ const GameInterface = () => {
   const [showEnd, setShowEnd] = useState(false)
   const [loading, setLoading] = useState(true)
   const [status, setStatus] = useState({ loaded: 0, total: 0, item: '' })
+  const [deficiency, setDeficiency] = useState('normal')
   const maps = useMemo(() => ({
     0: 'forest_map',
     1: 'desert_map',
@@ -51,8 +52,11 @@ const GameInterface = () => {
     setScore(0)
     setMapScores({})
     setShowEnd(false)
+    setDeficiency('normal')
     window.scrollTo(0, 0)
   }
+
+  const handleDeficiencyChange = type => setDeficiency(type)
 
   useEffect(() => {
     const mapList = Object.values(maps)
@@ -107,6 +111,7 @@ const GameInterface = () => {
           scores={mapScores}
           maps={Object.values(maps)}
           onRestart={handleRestart}
+          deficiency={deficiency}
         />
       ) : (
         <div className='game-interface'>
@@ -120,6 +125,7 @@ const GameInterface = () => {
             mapImporterName={maps[mapIndex]}
             nextMap={handleNextMap}
             addScore={addScore}
+            onDeficiencyChange={handleDeficiencyChange}
           />
         </div>
       )}

--- a/src/lib/SnakeGame.jsx
+++ b/src/lib/SnakeGame.jsx
@@ -5,7 +5,7 @@ import MobileControl from "../MobileControl"
 import snakeImages from "../snakeImages";
 // import mapImages from "./mapImages";
 
-const SnakeGame = ({ mapImporterName, nextMap, addScore }) => {
+const SnakeGame = ({ mapImporterName, nextMap, addScore, onDeficiencyChange }) => {
 
   const basePath = window.location.pathname.split("/")[1]
   const baseURL = (basePath) ? ("/" + basePath + "/") : ("")
@@ -146,6 +146,7 @@ const SnakeGame = ({ mapImporterName, nextMap, addScore }) => {
         SnakeSpriteImg.src = snakeImages[deficiency]
         snakeSpriteImgRef.current = SnakeSpriteImg
         setMapDeficiency(deficiency)
+        if (onDeficiencyChange) onDeficiencyChange(deficiency)
         index--
       }
     }
@@ -287,6 +288,7 @@ const SnakeGame = ({ mapImporterName, nextMap, addScore }) => {
   // Reset States when change map
   useEffect(() => {
     setLoaded(false)
+    if (onDeficiencyChange) onDeficiencyChange('normal')
   }, [mapImporterName])
 
   // Setup useEffect


### PR DESCRIPTION
## Summary
- show extra info about colour blindness on the end screen
- keep track of current colour vision deficiency
- notify GameInterface when the deficiency changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685032c2573c832b80ec26a0ab797207